### PR TITLE
Retrait des blocs de code pour délimiter les messages dans #python et #pygame

### DIFF
--- a/channels/4 - Salons d'aide/01_python.md
+++ b/channels/4 - Salons d'aide/01_python.md
@@ -24,62 +24,62 @@ langage Python
 
 __Voici un petit condensé des message épinglé pour ameliorer la lisibilité:__
 
-Apprendre python, par ou commencer?:
-https://discord.com/channels/763846236766732368/763849115238400063/785501088865320960
-*(message original par leo_85.pyd#0997 [279991875941826560] )*
+Apprendre python, par ou commencer?:<br/>
+https://discord.com/channels/763846236766732368/763849115238400063/785501088865320960<br/>
+*(message original par leo_85.pyd#0997 [279991875941826560] )*<br/>
 
-Concernant la sécurité informatique (piratage ou protection):
-https://discord.com/channels/763846236766732368/763849115238400063/962409349400113202
-*(message original par leo_85.pyd#0997 [279991875941826560] )*
+Concernant la sécurité informatique (piratage ou protection):<br/>
+https://discord.com/channels/763846236766732368/763849115238400063/962409349400113202<br/>
+*(message original par leo_85.pyd#0997 [279991875941826560] )*<br/>
 
-Problème ``no module named [...]``:
-https://discord.com/channels/763846236766732368/763849115238400063/956227416160874557
-*(message original par GAMINGDY#1882 [633710128004202516] )*
+Problème ``no module named [...]``:<br/>
+https://discord.com/channels/763846236766732368/763849115238400063/956227416160874557<br/>
+*(message original par GAMINGDY#1882 [633710128004202516] )*<br/>
 
-Problèmes avec pip:
-https://discord.com/channels/763846236766732368/763849115238400063/956225507601555526
-*(message original par canne_à_pêche#7041 [704779822890745986] )*
+Problèmes avec pip:<br/>
+https://discord.com/channels/763846236766732368/763849115238400063/956225507601555526<br/>
+*(message original par canne_à_pêche#7041 [704779822890745986] )*<br/>
 
-Comprendre l'asynchrone:
-https://discord.com/channels/763846236766732368/763849115238400063/953216963688136724
-*(message original par Dr Lazor#6737 [87605725857058816] )*
+Comprendre l'asynchrone:<br/>
+https://discord.com/channels/763846236766732368/763849115238400063/953216963688136724<br/>
+*(message original par Dr Lazor#6737 [87605725857058816] )*<br/>
 
-Créer un timer:
-https://discord.com/channels/763846236766732368/763849115238400063/935845300931809300
-*(message original par Victorem4Ever#1182 [348446010906902528] )*
+Créer un timer:<br/>
+https://discord.com/channels/763846236766732368/763849115238400063/935845300931809300<br/>
+*(message original par Victorem4Ever#1182 [348446010906902528] )*<br/>
 
-Différences entre les methodes "normales", les methodes de class et les methodes statiques:
-https://discord.com/channels/763846236766732368/763849115238400063/889455643113689088
-*(message original par horus#5799 [634745432148279306] )*
+Différences entre les methodes "normales", les methodes de class et les methodes statiques:<br/>
+https://discord.com/channels/763846236766732368/763849115238400063/889455643113689088<br/>
+*(message original par horus#5799 [634745432148279306] )*<br/>
 
-Les domaines d'éfficacité de Python:
-https://discord.com/channels/763846236766732368/763849115238400063/842820668856467457
-*(message original par Dr Lazor#6737 [87605725857058816] )*
+Les domaines d'éfficacité de Python:<br/>
+https://discord.com/channels/763846236766732368/763849115238400063/842820668856467457<br/>
+*(message original par Dr Lazor#6737 [87605725857058816] )*<br/>
 
-Le fonctionement des variables en Python:
-https://discord.com/channels/763846236766732368/763849115238400063/834107681853407275
-*(message original par horus#5799 [634745432148279306] )*
+Le fonctionement des variables en Python:<br/>
+https://discord.com/channels/763846236766732368/763849115238400063/834107681853407275<br/>
+*(message original par horus#5799 [634745432148279306] )*<br/>
 
-Faire un choix multiple avec input():
-https://discord.com/channels/763846236766732368/763849115238400063/826129628896821268
-*(message original par leo_85.pyd#0997 [279991875941826560] )*
+Faire un choix multiple avec input():<br/>
+https://discord.com/channels/763846236766732368/763849115238400063/826129628896821268<br/>
+*(message original par leo_85.pyd#0997 [279991875941826560] )*<br/>
 
-Le système d'import de Python:
-https://discord.com/channels/763846236766732368/763849115238400063/823973925351587850
-*(message original par leo_85.pyd#0997 [279991875941826560] )*
+Le système d'import de Python:<br/>
+https://discord.com/channels/763846236766732368/763849115238400063/823973925351587850<br/>
+*(message original par leo_85.pyd#0997 [279991875941826560] )*<br/>
 
-Ajouter Python au path:
-https://discord.com/channels/763846236766732368/763849115238400063/818208033309196320
-*(message original par GAMINGDY#1882 [633710128004202516] )*
+Ajouter Python au path:<br/>
+https://discord.com/channels/763846236766732368/763849115238400063/818208033309196320<br/>
+*(message original par GAMINGDY#1882 [633710128004202516] )*<br/>
 
-Mettre du code en forme sur discord:
-https://discord.com/channels/763846236766732368/763849115238400063/767478833585586246
-*(message original par RedsTom#4616 [723471302123323434] )*
+Mettre du code en forme sur discord:<br/>
+https://discord.com/channels/763846236766732368/763849115238400063/767478833585586246<br/>
+*(message original par RedsTom#4616 [723471302123323434] )*<br/>
 
-Faire des .exe avec python:
+Faire des .exe avec python:<br/>
 https://docs.drlazor.be/python_exe.md 
 
-Exercices de Python tout niveaux:
+Exercices de Python tout niveaux:<br/>
 https://github.com/Astremy/ProblemesAlgorithmiques/
 
 

--- a/channels/4 - Salons d'aide/01_python.md
+++ b/channels/4 - Salons d'aide/01_python.md
@@ -21,7 +21,7 @@ langage Python
 # Message(s) Épinglé(s)
 
 ## Message 1 (par leo_85.pyd#0997 [279991875941826560])
-```md
+
 __Voici un petit condensé des message épinglé pour ameliorer la lisibilité:__
 
 Apprendre python, par ou commencer?:
@@ -82,7 +82,6 @@ https://docs.drlazor.be/python_exe.md
 Exercices de Python tout niveaux:
 https://github.com/Astremy/ProblemesAlgorithmiques/
 
-```
 
 # Annexe 
 ## Originaux des messages cités plus haut, dans l'ordre, au cas ou il serais altérés/supprimés
@@ -90,7 +89,7 @@ https://github.com/Astremy/ProblemesAlgorithmiques/
 <br/>
 
 ### Apprendre python, par ou commencer?:
-```
+
 La plupart des débutants en programmation entreprennent des projets trop complexe pour eux sans s'en rendre compte. si vous apprenez la programmation depuis moins de 6 mois ~ 1 an et que vous avez des difficultés à avancer dans un projet qui concerne tkinter, discord.py, pygame, threading,  panda3D,  tenserflow, etc (liste non-exhaustive) sachez que c'est tout a fait normal et qu'il sera plus enrichissant pour vous de mettre ces projet en pause le temps d'étoffer votre apprentissage. En effet la manipulation de ces modules nécessite des connaissances relativement avancées parmis lesquelles:
 
 - programmation objet
@@ -103,13 +102,13 @@ La plupart des débutants en programmation entreprennent des projets trop comple
 (encore une fois liste non-exhaustive) si vous ne savez pas ce qu'est une fonction, un objet, ou manipuler les boucles comme for et while. vous avez tout a gagner a laisser votre projet de coté le temps de vous consolider et même entreprendre des projet plus a votre échelle afin d'accumuler des connaissance pour celui qui vous tient vraiment a cœur.
 Ne soyez pas effrayé de lâcher un projet pendant plusieurs mois, accumuler de la frustration en échouant continuellement sur une librairie de trop haut niveau peux vous dégouter de la programmation en général, cela serais contre productif.
 
-Vous trouverez un bon cours a cette adresse: https://inforef.be/swi/download/apprendre_python3_5.pdf
-et pour les personnes qui preferent les vidéos: https://www.youtube.com/watch?v=HWxBtxPBCAc&list=PLrSOXFDHBtfHg8fWBd7sKPxEmahwyVBkC et https://www.youtube.com/watch?v=HVN4qv6Dxdk&list=PLrSOXFDHBtfEiSgOG1FM4oq-yS24iV4s1
-```
+Vous trouverez un bon cours a [cette adresse](https://inforef.be/swi/download/apprendre_python3_5.pdf)
+et pour les personnes qui preferent les video [ici](https://www.youtube.com/watch?v=HWxBtxPBCAc&list=PLrSOXFDHBtfHg8fWBd7sKPxEmahwyVBkC) et [la](https://www.youtube.com/watch?v=HVN4qv6Dxdk&list=PLrSOXFDHBtfEiSgOG1FM4oq-yS24iV4s1)
+
 <br/>
 
 ### Concernant la sécurité informatique (piratage ou protection):
-```
+
 Il y a souvent des question illégales mais pas malveillantes ici comme "Comment je surcharge mon propre site de demandes de connection pour voir si il tient la charge?", "Comment j'attaque mon propre programme pour voir si il est sûr?", "Comment les pirates informatiques s'y prennent pour faire X?" etc... 
 
 Vous pouvez nous garantir autant que vous voulez que vos intentions sont honnêtes: on est sur internet, on ne vous connais pas (pour la plupart du staff on ne se connais même pas entre nous) bref nous n'avons aucune garantie que vous êtes réellement honnête
@@ -118,11 +117,11 @@ Ici (serveur discord de Graven) personne n'est **à la fois** compétant **et** 
 sachez toute fois que le serveur discord ``Not a Name`` possède un tel salon mais l'entrée y est extrêmement sélective
 
 Pour les question de sécurité côté protection par contre  comme "Comment je protège ma base de donnée?", "Comment je stoque les mots de passe de mes utilisateurs?", etc étant donné que ca n'est pas illégal il n'y a aucune raison de ne pas vous aider.
-```
+
 <br/>
 
 ### Problème ``no module named [...]``:
-```
+
 Vous avez l'erreur ``No module name 'package_name'``, pourtant vous êtes sûr d'avoir installé ledit package ?
 
 Tout d'abord vérifiez si vous avez un dossier ``.env`` ou ``.venv`` dans votre projet. **Si vous n'en voyez pas, vérifiez si vous avez activé l'option "afficher les fichiers cachés" dans votre explorateur de fichiers**, il est fort probable que vous ayez installé le package dans un environnement virtuel, surtout si vous avez créé le projet depuis Pycharm par exemple.
@@ -133,84 +132,84 @@ Si vous avez bien un dossier ``.env`` ou ``.venv``, **attention, les commandes s
 pour les utilisateurs Mac essayez la commande de Linux peut-être qu'elle va fonctionner. 🙃 
 
 Si les dossiers ne sont pas présents alors vous pouvez faire ``pip install package_name``
-```
+
 <br/>
 
 ### Problèmes avec pip:
-```
+
 Pip permet d'installer des packages (= bibliothèques, modules) avec la commande ``pip install <package>``.
 Mais vous pouvez rencontrer des erreurs parmis lesquelles:
 
 **1. Commande non reconnue**
-\`\`\`
+```
 'pip’ n'est pas reconnu en tant que commande interne
 ou externe, un programme exécutable ou un fichier de commandes
-\`\`\`
+```
 
 Pour régler cette erreur, il faut ajouter les modules commandes de python (pip, wheel...) au path, ou faire ``py -m pip install <package>`` sur windows / ``python -m pip install <package>`` sur unix-like.
 
 **2. No module named pip**
 Vous utilisez la deuxième option (avec -m pip), mais vous obtenez :
-\`\`\`
+```
 No module named pip
-\`\`\`
+```
 
 Dans ce cas, pip n'est simplement... pas installé. Pour l'installer, voici la documentation officielle : https://pip.pypa.io/en/stable/installation/
 
 **3. Package installé, mais erreur dans le code**
-\`\`\`
+```
 ModuleNotFoundError: No module named <package>
-\`\`\`
+```
 Vous avez installé le package, mais ça ne marche pas ? Le module est sûrement installé sur le mauvais python.
 Par exemple, votre ordinateur a python version 3.9, et 3.10 : si vous lancez votre code avec ce dernier mais installez le package avec le premier, ça ne fonctionenra pas. Pour régler ça, faites :
-\`\`\`py
+```py
 # Remplacez 3.10 par la version avec laquelle vous lancez le code
 # Windows
 py -3.10 -m pip install <package>
 # Unix like
 python3.10 -m pip install <package>
-\`\`\`
 ```
 
+
 ### Comprendre l'asynchrone:
-```
+
 Vous ne connaissez rien à l'asynchrone?
 
 Voici une liste de références que je trouve intéressante à lire pour comprendre l'art de la programmation événementielle (sans ordre particulier):
 
-Théorie
-https://zestedesavoir.com/articles/152/la-puissance-cachee-des-coroutines/ (nohar; coroutines)
-https://zestedesavoir.com/articles/1568/decouvrons-la-programmation-asynchrone-en-python/ (nohar; asyncio)
-https://dabeaz.com/finalgenerator/index.html (beazley; generators)
-http://ithare.com/multi-coring-and-non-blocking-instead-of-multi-threading-with-a-script/ (ithare; os design)
-http://www.kegel.com/c10k.html (kegel; network design)
-https://vorpus.org/blog/notes-on-structured-concurrency-or-go-statement-considered-harmful/ (njs; go statement considered harmful MUST READ)
-https://lwn.net/Articles/724082/ (trio meta)
-https://accu.org/journals/overload/23/130/schmidt_2185/ (cpu clocks and interrupts, os scheduler)
+Théorie<br/>
+https://zestedesavoir.com/articles/152/la-puissance-cachee-des-coroutines/ (nohar; coroutines)<br/>
+https://zestedesavoir.com/articles/1568/decouvrons-la-programmation-asynchrone-en-python/ (nohar; asyncio)<br/>
+https://dabeaz.com/finalgenerator/index.html (beazley; generators)<br/>
+http://ithare.com/multi-coring-and-non-blocking-instead-of-multi-threading-with-a-script/ (ithare; os design)<br/>
+http://www.kegel.com/c10k.html (kegel; network design)<br/>
+https://vorpus.org/blog/notes-on-structured-concurrency-or-go-statement-considered-harmful/ (njs; go statement considered harmful MUST READ)<br/>
+https://lwn.net/Articles/724082/ (trio meta)<br/>
+https://accu.org/journals/overload/23/130/schmidt_2185/ (cpu clocks and interrupts, os scheduler)<br/>
 
-L'avis très critique d'Armin Ronacher (fondateur de flask) sur asyncio
-https://lucumr.pocoo.org/2016/10/30/i-dont-understand-asyncio/ (assez dépassé)
-https://lucumr.pocoo.org/2020/1/1/async-pressure/ (bien d'actualité)
+L'avis très critique d'Armin Ronacher (fondateur de flask) sur asyncio<br/>
+https://lucumr.pocoo.org/2016/10/30/i-dont-understand-asyncio/ (assez dépassé)<br/>
+https://lucumr.pocoo.org/2020/1/1/async-pressure/ (bien d'actualité)<br/>
 
-Vidéos
-https://youtu.be/9zinZmE3Ogk (hettinger; concurrency)
-https://youtu.be/iG6fr81xHKA (grinberg; async python beginner)
-https://youtu.be/x1ndXuw7S0s (beazley; live coding: event loop from scratch)
+Vidéos<br/>
+https://youtu.be/9zinZmE3Ogk (hettinger; concurrency)<br/>
+https://youtu.be/iG6fr81xHKA (grinberg; async python beginner)<br/>
+https://youtu.be/x1ndXuw7S0s (beazley; live coding: event loop from scratch)<br/>
 
-Asyncio/Curio/Trio (si vous pouvez, donnez sa chance à Trio)
-https://docs.python.org/3/library/asyncio.html#module-asyncio
-https://pymotw.com/3/asyncio/index.html
-https://curio.readthedocs.io/en/latest/
-https://trio.readthedocs.io/en/stable/
+Asyncio/Curio/Trio (si vous pouvez, donnez sa chance à Trio)<br/>
+https://docs.python.org/3/library/asyncio.html#module-asyncio<br/>
+https://pymotw.com/3/asyncio/index.html<br/>
+https://curio.readthedocs.io/en/latest/<br/>
+https://trio.readthedocs.io/en/stable/<br/>
 
-Ma contribution personelle
+Ma contribution personelle<br/>
 https://git.drlazor.be/?p=pyloop;a=
-summary (lazor; basic event loop)
-https://youtu.be/oVQAyQF9jy8 (astremy & lazor; live coding: async network server)
-```
+summary (lazor; basic event loop)<br/>
+https://youtu.be/oVQAyQF9jy8 (astremy & lazor; live coding: async network server)<br/>
+
 
 ### Créer un timer:
-```
+
 Cette question revient souvent :
 Comment faire un timer qui ne bloque pas ?
 
@@ -223,27 +222,27 @@ Pour récupérer une timestamp il suffit d'appeler la fonction time comme cela :
 
 
 Maintenant, il faut comparer votre temps initial, que vous stockerez dans une variable, avec le temps actuel.
-\`\`\`py
+```py
 start = time.time()
 # do something
 print(time.time() - start) # temps actuel - temps initial = durée
-\`\`\`
+```
 
 Vous aurez donc le temps en seconde qui s'est écoulé depuis que vous avez assigné start
 
 
 Un usage possible :
 dans une boucle :
-\`\`\`py
+```py
 start = time.time()
 while time.time() - start <= 10:
     # do something
-\`\`\`
-La boucle s'arrêtera après 10 secondes.
 ```
+La boucle s'arrêtera après 10 secondes.
+
 
 ### Différences entre les methodes "normales", les methodes de class et les methodes statiques:
-```
+
 Il y a trois types de méthodes :
 - méthodes "normales"
 - méthodes de classe (``@classmethod``)
@@ -253,10 +252,10 @@ Une méthode de classe prend en paramètre la classe de la méthode. ``f(cls, *a
 Une méthode statique est une fonction libre dans l'espace de nom de la classe. ``f(*args)``
 
 Une méthode statique est, entre guillemets, "indépendante" d'une classe ou d'une instance. 
-```
+
 
 ### Les domaines d'éfficacité de python:
-```
+
 Python carbure pour:
 - **Le développement d'applications web.** Il existe de nombreux framework pour tous les goûts et leur performances sont décentes. Dropbox, Youtube et Instagram utilisent python par exemple. Django, Flask, Aiohttp sont quelques exemples de frameworks.
 - **L'analyse et le traitement de très gros volumes de données** à des fins statistiques, de traitement du signal, de traitement du langage ou d’inteligence artificielle. Python est un langage de programmation très prisé par la communauté scientifique qui l'utilise au travers des bibliothèques comme numpy, matplotlib, panda, tensorflow ou pytorch.
@@ -267,10 +266,10 @@ A contrario, Python **__n'est pas__** le langage que je recommanderais pour les 
 - **Les système à performance critiques** où l'on essaie de tirer un maximum de la puissance brute de la machine. Un programme écrit en pure python sera de 10 à 100 fois plus lent qu'un équivalent en C ou en Go. N'essayez pas de développer un moteur de jeu en python, vous faites fausse route.
 - **Les applications graphiques**, python est un langage assez pauvre en terme de bibliothèques adaptés aux interfaces graphiques.
 - **Le développement mobile**, jusqu'à peu il n'y avait tout simplement pas moyen de de déployer un programme python ni sur android ni sur iOS.
-```
+
 
 ### Le fonctionement des variables en python:
-```
+
 En Python, on ne manipule jamais des valeurs, mais toujours des références !
 
 Soit ``b`` une variable référençant un objet quelconque.
@@ -286,66 +285,66 @@ Les cas suivants augmentent le compteur de références de l'objet référencé 
 Les cas suivants décrémentent le compteur de références de l'objet référencé par la variable b.
 - fin d'un scope et destruction de son contexte (ex : fin d'une fonction, d'un générateur, etc...)
 - opérateur de "unbind" del : del b
-```
+
 
 ### Faire un choix multiple avec input():
-```
+
 Quelque chose que je vois beaucoup trop ici:
-\`\`\`py
+```py
 if reponse in ("oui", "Oui", "OuI", "OUi", "OUI", "oUI", "oUi", "ouI"):
     # code
-\`\`\`
-écrivez plutot:
-\`\`\`py
-if reponse.lower() == "oui":
-\`\`\`
-et si il y a plusieurs choix:
-\`\`\`py
-if reponse.lower() in ("oui", "non"):
-\`\`\`
-Les methodes lower et upper convertissent les chaines de caractère respectivement  en minuscule et en majuscule, et comme les str sont des types immuable ca ne change rien a l'état de la chaine d'origine.
 ```
+écrivez plutot:
+```py
+if reponse.lower() == "oui":
+```
+et si il y a plusieurs choix:
+```py
+if reponse.lower() in ("oui", "non"):
+```
+Les methodes lower et upper convertissent les chaines de caractère respectivement  en minuscule et en majuscule, et comme les str sont des types immuable ca ne change rien a l'état de la chaine d'origine.
+
 
 ### Le système d'import de python:
-```
+
 En programmation on déteste réimplémenter la roue, on met donc du code réutilisable dans des modules.
 La meilleur facon d'importer un module c'est le classique:
-\`\`\`py
+```py
 import foo
-\`\`\`
+```
 Par la suite si on veux utiliser une fonction bar du module foo on fera bêtement
-\`\`\`py
+```py
 foo.bar()
-\`\`\`
+```
 C'est la methode la plus recommandé puisqu'a la relecture d'un code on sait tout de suite d'où vient quoi (ca se lis a l'envers: "la fonction bar du module foo")
 quand on utilise entre 1 et (grand max) 5 éléments d'un module on peu passer par from/import 
-\`\`\`py
+```py
 from foo import bar, spam, egg
-\`\`\`
+```
 en faisant ca les noms sont directement ajouté au namespace courant on écrira donc bar(), spam(), egg() au lieux de foo.bar(), foo.spam() et foo.egg()
 Ca reste encore relativement propre/lisible puisqu'un coup d'oeil aux imports permet de savoir d'ou vient quoi.
 
 enfin il reste le "star import" qui permet de tuer la lisibilité de son code, de se perdre dans qu'est ce qui appartient a qui et de "ah oui mais non cette fonction la a été écrasé trois fois"
-\`\`\`py
+```py
 from foo import *
-\`\`\`
+```
 cette syntaxe deverse tout le contenu du module dans le namespace courant et cela peux entrainer beaucoup de problèmes, notament l'impossibilité de savoir d'ou vient quoi mais surtout l'écrasement des noms identiques.
 Mettons trois module A, B et C qui contiennent tous le nom Draw:
-\`\`\`py
+```py
 from A import * # ou Draw est une variable
 from B import * # ou Draw est une fonction
 from C import * # ou Draw est un objet
 
 a = Draw #c'est quoi a?
-\`\`\`
+```
 Pire que ca si je crée un nom Draw dans mon programme j'écrase toute les références de Draw des modules que j'ai importé dans éon namespace.
 Bref toujours être sûr de ce qu'on fait avec les star import
 
-(une dernière chose pour les \`\`import truc as machin\`\`. on réservera cette syntaxe au librairies tierces comme Tkinter ou numpy et pas a la librairie standard)
-```
+(une dernière chose pour les ``import truc as machin``. on réservera cette syntaxe au librairies tierces comme Tkinter ou numpy et pas a la librairie standard)
+
 
 ### Ajouter python au path:
-```
+
 __**Comment ajouter Python au PATH:**__
 
 __Étape 1:__
@@ -361,31 +360,30 @@ __Étape finale:__
 Nous voilà dans le dernier menu, parmis les différents choix choisir ``Add python to environn..``  et enfin ``install``
 
 Et voilà maintenant vous avez réussi à ajouter Python au PATH
-```
+
 ### Mettre du code en forme sur discord:
-```
-Si vous voulez coller votre code dans discord, voici la procédure à suivre : 
-\`\`\`language
-Votre code
+
+Si vous voulez coller votre code dans discord, voici la procédure à suivre : <br/><br/>
+\`\`\`language<br/>
+Votre code<br/>
 \`\`\`
 
 Ce qui donne :
-\`\`\`java
+```java
 public static void main(String[] args){
   int i = 5;
 }
-\`\`\`
+```
 
 Pour le texte :
-\\`\\`\\`java
-public static void main(String[] args){
-  int i = 5;
-}
-\\`\\`\\`
+\`\`\`java<br/>
+public static void main(String[] args){<br/>
+  int i = 5;<br/>
+}<br/>
+\`\`\`
 
 Si votre code est trop **grand** pour discord, veuillez utiliser hastebin ou github gist :
  - https://hastebin.com/ (peut parfois ne pas marcher, temporaire)
  - https://gist.github.com/ (requiert un compte, permanent)
 
 Les 2 sites sont presque identiques, si l'un ne marche pas utilisez l'autre
-```

--- a/channels/4 - Salons d'aide/02_pygame.md
+++ b/channels/4 - Salons d'aide/02_pygame.md
@@ -16,7 +16,7 @@ librairie Pygame
 # Message(s) Épinglé(s)
 
 ## Message 1 (par leo_85.pyd#0997 [279991875941826560])
-```
+
 Petits rappels de base qui (je pense) ne feront de mal à personne :
 
 - la série pygame de graven n'est pas un cours de python, elle suppose que vous avez déjà appris le langage et que vous avez une certaine pratique.
@@ -28,11 +28,12 @@ Petits rappels de base qui (je pense) ne feront de mal à personne :
 
 plus de détails sur la nécessité d'apprendre le python avant d'attaquer un gros projet comme un jeu vidéo ici :
 https://discord.com/channels/763846236766732368/763849115238400063/785501088865320960
-```
-note: le dernier lien de ce message se réfère au [premier message épinglé du salon python](https://github.com/desaleo/ServeurDiscord/blob/master/channels/4%20-%20Salons%20d'aide/01_python.md)
+
+### note:
+ le dernier lien de ce message se réfère au [premier message épinglé du salon python](https://github.com/desaleo/ServeurDiscord/blob/master/channels/4%20-%20Salons%20d'aide/01_python.md)
 
 ## Message 2 (par Graven#4949 [238326044988276738])
-```
+
 Yo les devs ! J'épingle ce message pour l'aide sur la derniere video pygame.
 
 **Comment faire si mon code de l'episode 1 ne fonctionne pas ?**
@@ -51,15 +52,14 @@ Tu dois placer des rectangles pile poil sur la tuile sinon la détéction ne se 
 1. Remet la video en arrière pour voir si tu n'as pas loupé une étape 
 2. As tu bien mit le bon nom de variable ? "tmxdata" est different de "tmx_data".
 
-⚠️ Merci de ne spammer le canal de 78 captures d'ecran illisible et d'expliquer clairement le problème en indiquant le minutage.
+⚠️ Merci de ne spammer le canal de 78 captures d'écran illisible et d'expliquer clairement le problème en indiquant le minutage.
 
 Vous avez la possibilité de me mentionner ou pm si besoin (me relancer au bout de 24h si je ne repond pas)
-```
+
 ## Message 3 (par Graven#4949 [238326044988276738])
-```
+
 Si vous avez besoin d'aide sur mes videos pygame go me mp (j'accepte tout le monde en amis)
-```
+
 ## Message 4 (par Graven#4949 [238326044988276738])
-```
+
 https://www.youtube.com/watch?v=9lUh_3RItAY
-```


### PR DESCRIPTION
retrait des blocs de code pour délimiter les messages pour:
- rester consistant avec les modifications apportées a 03_java-jvm.md
- améliorer la lisibilité des-dits messages
- les messages sont déjà proprement séparé